### PR TITLE
fix(ci): use ExportRelease build configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           dotnet-version: '9.0.x'
 
       - name: Build and bundle
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration ExportRelease
         # The BundleRelease MSBuild target copies all mod files to release/
 
       - name: Zip release directory


### PR DESCRIPTION
The Godot solution does not have a Release config; valid options are Debug, ExportDebug, and ExportRelease.