### PR TITLE
feat: campfire support for >4 players and --save-dir launch arg

### DIFF
--- a/CampfirePatch.cs
+++ b/CampfirePatch.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Logging;
+using MegaCrit.Sts2.Core.Nodes.Rooms;
+using MegaCrit.Sts2.Core.Nodes.RestSite;
+
+namespace Sts2Unlimited;
+
+public static class CampfirePatch
+{
+    private static readonly MethodInfo _safeAddMethod =
+        typeof(CampfirePatch).GetMethod(nameof(SafeAddToContainer),
+            BindingFlags.Public | BindingFlags.Static)!;
+
+    /// <summary>
+    /// Bounds-safe replacement for _characterContainers[i].AddChildSafely(character).
+    /// Players beyond the 4 hardcoded scene slots are added to the last valid container so
+    /// that their scene nodes are initialised and callbacks (ShowSelectedRestSiteOption, etc.)
+    /// do not throw NullReferenceException.  They will overlap visually in that slot.
+    /// </summary>
+    public static void SafeAddToContainer(List<Control> containers, int index, NRestSiteCharacter character)
+    {
+        int clampedIndex = Math.Min(index, containers.Count - 1);
+        containers[clampedIndex].AddChildSafely(character);
+    }
+
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> Transpile_Ready(IEnumerable<CodeInstruction> instructions)
+    {
+        var codes = new List<CodeInstruction>(instructions);
+
+        // Target pattern in IL:
+        //   ldfld     _characterContainers        ← load the list field (preceded by ldarg.0)
+        //   ldloc     <i>                          ← load loop index
+        //   callvirt  List<Control>.get_Item       ← _characterContainers[i]  (crashes when i >= 4)
+        //   ldloc     <nRestSiteCharacter>         ← load the character
+        //   call      AddChildSafely               ← extension method call
+        //
+        // Replacement:
+        //   ldfld     _characterContainers
+        //   ldloc     <i>
+        //   ldloc     <nRestSiteCharacter>
+        //   call      CampfirePatch.SafeAddToContainer   ← bounds-checked helper
+
+        var listGetItem = typeof(List<Control>).GetMethod("get_Item");
+        var characterContainersField = typeof(NRestSiteRoom)
+            .GetField("_characterContainers", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        if (characterContainersField == null)
+        {
+            Log.LogMessage(LogLevel.Error, LogType.Generic,
+                "[CampfirePatch] Could not find _characterContainers field — campfire patch skipped");
+            return codes;
+        }
+
+        bool patched = false;
+        for (int i = 0; i < codes.Count - 4; i++)
+        {
+            if (codes[i].opcode == OpCodes.Ldfld &&
+                codes[i].operand is FieldInfo f && f == characterContainersField &&
+                codes[i + 2].opcode == OpCodes.Callvirt &&
+                codes[i + 2].operand is MethodInfo m && m == listGetItem)
+            {
+                // Remove callvirt get_Item at i+2; shifts i+3 → i+2, i+4 → i+3
+                codes.RemoveAt(i + 2);
+
+                // Replace the original AddChildSafely call (now at i+3) with our helper
+                codes[i + 3] = new CodeInstruction(OpCodes.Call, _safeAddMethod);
+
+                patched = true;
+                break; // only one such site in _Ready
+            }
+        }
+
+        if (!patched)
+            Log.LogMessage(LogLevel.Warn, LogType.Generic,
+                "[CampfirePatch] Pattern not found in NRestSiteRoom._Ready — campfire patch may be ineffective");
+
+        return codes;
+    }
+}

--- a/SaveDirPatch.cs
+++ b/SaveDirPatch.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Logging;
+using MegaCrit.Sts2.Core.Saves;
+
+namespace Sts2Unlimited;
+
+public static class SaveDirPatch
+{
+    public static bool Prefix_ConstructDefault(ref SaveManager __result)
+    {
+        string saveDir = CommandLineHelper.GetValue("save-dir");
+
+        if (string.IsNullOrWhiteSpace(saveDir))
+            return true; // no arg — let original run
+
+        Log.LogMessage(LogLevel.Info, LogType.Generic,
+            $"[SaveDirPatch] --save-dir detected: '{saveDir}'. Redirecting all save I/O.");
+
+        ISaveStore store = new GodotFileIo(saveDir);
+        __result = new SaveManager(store);
+        return false; // skip original ConstructDefault
+    }
+
+    public static void ReplaceInstance()
+    {
+        string saveDir = CommandLineHelper.GetValue("save-dir");
+        if (string.IsNullOrWhiteSpace(saveDir))
+            return;
+
+        var instance = SaveManager.Instance;
+        if (instance == null)
+        {
+            Log.LogMessage(LogLevel.Warn, LogType.Generic,
+                "[SaveDirPatch] SaveManager.Instance is null — live store replacement skipped");
+            return;
+        }
+
+        // Swap the ISaveStore field on the existing instance rather than replacing the whole
+        // singleton. This preserves already-loaded state (settings, locale prefs, etc.) so that
+        // subsequent game systems (LocManager, etc.) can still read from it — only future
+        // reads/writes are redirected to the custom path.
+        var storeField = typeof(SaveManager)
+            .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault(f => typeof(ISaveStore).IsAssignableFrom(f.FieldType));
+
+        if (storeField == null)
+        {
+            Log.LogMessage(LogLevel.Warn, LogType.Generic,
+                "[SaveDirPatch] ISaveStore field not found on SaveManager — live store replacement skipped");
+            return;
+        }
+
+        storeField.SetValue(instance, new GodotFileIo(saveDir));
+        Log.LogMessage(LogLevel.Info, LogType.Generic,
+            $"[SaveDirPatch] SaveManager store swapped — all save I/O now goes to '{saveDir}'");
+    }
+}

--- a/Sts2Unlimited.cs
+++ b/Sts2Unlimited.cs
@@ -132,6 +132,52 @@ public static class Sts2Unlimited
 				harmony.Patch(customInitMethod, prefix: new HarmonyMethod(customPatch));
 				Log.LogMessage(LogLevel.Debug, LogType.Generic, "Patched NCustomRunScreen.InitializeMultiplayerAsHost");
 			}
+
+			// Patch NRestSiteRoom._Ready to handle >4 players at the campfire
+			var restSiteRoomType = typeof(MegaCrit.Sts2.Core.Nodes.Rooms.NRestSiteRoom);
+			var restSiteReadyMethod = restSiteRoomType.GetMethod(
+				"_Ready",
+				BindingFlags.Public | BindingFlags.Instance,
+				null,
+				Type.EmptyTypes,
+				null
+			);
+
+			if (restSiteReadyMethod != null)
+			{
+				var campfireTranspiler = typeof(CampfirePatch).GetMethod(
+					nameof(CampfirePatch.Transpile_Ready),
+					BindingFlags.Public | BindingFlags.Static);
+				harmony.Patch(restSiteReadyMethod, transpiler: new HarmonyMethod(campfireTranspiler));
+				Log.LogMessage(LogLevel.Debug, LogType.Generic, "Patched NRestSiteRoom._Ready (campfire fix)");
+			}
+
+			// Patch SaveManager.ConstructDefault to honour --save-dir launch arg
+			var saveManagerType = typeof(MegaCrit.Sts2.Core.Saves.SaveManager);
+			var constructDefaultMethod = saveManagerType.GetMethod(
+				"ConstructDefault",
+				BindingFlags.NonPublic | BindingFlags.Static,
+				null,
+				Type.EmptyTypes,
+				null
+			);
+
+			if (constructDefaultMethod != null)
+			{
+				var saveDirPrefix = typeof(SaveDirPatch).GetMethod(
+					nameof(SaveDirPatch.Prefix_ConstructDefault),
+					BindingFlags.Public | BindingFlags.Static);
+				harmony.Patch(constructDefaultMethod, prefix: new HarmonyMethod(saveDirPrefix));
+				Log.LogMessage(LogLevel.Debug, LogType.Generic, "Patched SaveManager.ConstructDefault (save-dir support)");
+			}
+			else
+			{
+				Log.LogMessage(LogLevel.Warn, LogType.Generic,
+					"[SaveDirPatch] SaveManager.ConstructDefault not found — save-dir patch skipped");
+			}
+
+			// Replace already-created singleton if --save-dir is present
+			SaveDirPatch.ReplaceInstance();
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
Resolves #3 

## Summary

- **Campfire fix**: Transpiles `NRestSiteRoom._Ready` to clamp the character container index — players 5+ are placed in the last valid slot rather than triggering an out-of-bounds crash. Fixes `NullReferenceException` in `ShowSelectedRestSiteOption` when extra players interact with rest site options.
- **`--save-dir` support**: Harmony prefix on `SaveManager.ConstructDefault` redirects save I/O to a custom path. `ReplaceInstance()` swaps the `ISaveStore` field on the already-created singleton (rather than replacing the whole instance, which would break `LocManager` and other systems that read from it during startup).

## Test plan

- [x] Launch with 5+ players and visit a campfire — all players can select rest site options without error
- [x] Launch with `--save-dir=user://host` — confirm log shows `[SaveDirPatch] SaveManager store swapped` and saves go to the custom path
- [x] Launch without `--save-dir` — confirm normal save behaviour is unchanged
- [x] Verify no regression on multiplayer lobby size patches

🤖 Generated with [Claude Code](https://claude.com/claude-code)