### PR TITLE
ci: re-enable Nexus Mods upload with v1.0.0-beta.3 action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,13 +132,11 @@ jobs:
           files: Sts2Unlimited.zip
           generate_release_notes: true
 
-      ## Currently disabled due to upload API being disabled
-      # - name: Upload to Nexus Mods
-      #   uses: Nexus-Mods/upload-action@v1.0.0-beta.1.1
-      #   with:
-      #     api_key: ${{ secrets.NEXUS_API_KEY }}
-      #     game_domain_name: slaythespire2
-      #     file_id: 55
-      #     filename: Sts2Unlimited.zip
-      #     version: ${{ steps.version.outputs.version }}
-      #     file_category: main
+      - name: Upload to Nexus Mods
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.3
+        with:
+          api_key: ${{ secrets.NEXUS_API_KEY }}
+          file_group_id: 7166860
+          filename: Sts2Unlimited.zip
+          version: ${{ steps.version.outputs.version }}
+          file_category: main


### PR DESCRIPTION
The upload API is now in open beta. Updates the action from
v1.0.0-beta.1.1 to v1.0.0-beta.3 and migrates from the old
`game_domain_name` + `file_id` parameters to the new `file_group_id`
(7166860) introduced in v1.0.0-beta.2.