### PR TITLE
Fix case-sensitive DLL filename in copy targets for Linux build

### DIFF
--- a/sts2unlimited.csproj
+++ b/sts2unlimited.csproj
@@ -12,7 +12,7 @@
 
   <Target Name="BundleRelease" AfterTargets="Build">
     <ItemGroup>
-      <ReleaseFiles Include="$(OutDir)Sts2Unlimited.dll" />
+      <ReleaseFiles Include="$(OutDir)sts2unlimited.dll" />
       <ReleaseFiles Include="$(OutDir)0Harmony.dll" />
       <ReleaseFiles Include="Sts2Unlimited.pck" />
       <ReleaseFiles Include="Sts2Unlimited.json" />
@@ -27,7 +27,7 @@
 
   <Target Name="DeployToGame" AfterTargets="BundleRelease" Condition="'$(STS2_MOD_DIR)' != ''">
     <ItemGroup>
-      <DeployFiles Include="$(OutDir)Sts2Unlimited.dll" />
+      <DeployFiles Include="$(OutDir)sts2unlimited.dll" />
       <DeployFiles Include="$(OutDir)0Harmony.dll" />
       <DeployFiles Include="Sts2Unlimited.pck" />
       <DeployFiles Include="Sts2Unlimited.json" />

--- a/sts2unlimited.csproj
+++ b/sts2unlimited.csproj
@@ -4,6 +4,7 @@
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReleaseDir>$(MSBuildProjectDirectory)\release</ReleaseDir>
+    <AssemblyName>Sts2Unlimited</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="./sts2.dll"/>
@@ -12,7 +13,7 @@
 
   <Target Name="BundleRelease" AfterTargets="Build">
     <ItemGroup>
-      <ReleaseFiles Include="$(OutDir)sts2unlimited.dll" />
+      <ReleaseFiles Include="$(OutDir)Sts2Unlimited.dll" />
       <ReleaseFiles Include="$(OutDir)0Harmony.dll" />
       <ReleaseFiles Include="Sts2Unlimited.pck" />
       <ReleaseFiles Include="Sts2Unlimited.json" />
@@ -27,7 +28,7 @@
 
   <Target Name="DeployToGame" AfterTargets="BundleRelease" Condition="'$(STS2_MOD_DIR)' != ''">
     <ItemGroup>
-      <DeployFiles Include="$(OutDir)sts2unlimited.dll" />
+      <DeployFiles Include="$(OutDir)Sts2Unlimited.dll" />
       <DeployFiles Include="$(OutDir)0Harmony.dll" />
       <DeployFiles Include="Sts2Unlimited.pck" />
       <DeployFiles Include="Sts2Unlimited.json" />


### PR DESCRIPTION
On Linux, the build outputs sts2unlimited.dll (lowercase) but the
BundleRelease and DeployToGame targets referenced Sts2Unlimited.dll,
causing MSB3030 errors in CI.