### PR TITLE
fix: restore InitializeMultiplayerAsHost maxPlayers override

### DIFF
--- a/Sts2Unlimited.cs
+++ b/Sts2Unlimited.cs
@@ -144,6 +144,59 @@ public static class Sts2Unlimited
 					$"[HostPatch] StartENetHost(UInt16, int) NOT FOUND on NetHostGameService. Members: {netHostMethodList}");
 			}
 
+			// Patch NCharacterSelectScreen.InitializeMultiplayerAsHost — this is what actually
+			// governs how many players StartRunLobby will seat (see TryAddPlayerInFirstAvailableSlot,
+			// which loops slot indices only up to MaxPlayers). StartSteamHost/StartENetHost's
+			// maxClients only controls the transport-level accept limit (Steam lobby member count /
+			// ENet socket cap); leaving this one at vanilla's hardcoded 4 meant the 5th+ player could
+			// connect at the network level but still get refused a run slot. Previously removed in
+			// b215ae7 on a since-unconfirmed theory that it caused a partial-lobby black screen —
+			// IsAboutToBeginGame/BeginRunForAllPlayersIfAllReady only wait on the players actually
+			// present in StartRunLobby.Players, not on MaxPlayers, so that shouldn't reproduce here.
+			var charSelectType = typeof(MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect.NCharacterSelectScreen);
+			var charInitMethod = charSelectType.GetMethod(
+				"InitializeMultiplayerAsHost",
+				BindingFlags.Public | BindingFlags.Instance,
+				null,
+				[typeof(INetGameService), typeof(int)],
+				null
+			);
+
+			if (charInitMethod != null)
+			{
+				var charPatch = typeof(Sts2Unlimited).GetMethod(nameof(Patch_LobbyInitMaxPlayers), BindingFlags.NonPublic | BindingFlags.Static);
+				harmony.Patch(charInitMethod, prefix: new HarmonyMethod(charPatch));
+				Log.LogMessage(LogLevel.Info, LogType.Generic, "[HostPatch] Patched NCharacterSelectScreen.InitializeMultiplayerAsHost");
+			}
+			else
+			{
+				Log.LogMessage(LogLevel.Warn, LogType.Generic,
+					"[HostPatch] NCharacterSelectScreen.InitializeMultiplayerAsHost(INetGameService, int) NOT FOUND.");
+			}
+
+			// Patch NCustomRunScreen.InitializeMultiplayerAsHost — same reasoning as above, for the
+			// Custom Run host flow.
+			var customRunType = typeof(MegaCrit.Sts2.Core.Nodes.Screens.CustomRun.NCustomRunScreen);
+			var customInitMethod = customRunType.GetMethod(
+				"InitializeMultiplayerAsHost",
+				BindingFlags.Public | BindingFlags.Instance,
+				null,
+				[typeof(INetGameService), typeof(int)],
+				null
+			);
+
+			if (customInitMethod != null)
+			{
+				var customPatch = typeof(Sts2Unlimited).GetMethod(nameof(Patch_LobbyInitMaxPlayers), BindingFlags.NonPublic | BindingFlags.Static);
+				harmony.Patch(customInitMethod, prefix: new HarmonyMethod(customPatch));
+				Log.LogMessage(LogLevel.Info, LogType.Generic, "[HostPatch] Patched NCustomRunScreen.InitializeMultiplayerAsHost");
+			}
+			else
+			{
+				Log.LogMessage(LogLevel.Warn, LogType.Generic,
+					"[HostPatch] NCustomRunScreen.InitializeMultiplayerAsHost(INetGameService, int) NOT FOUND.");
+			}
+
 			// Patch NRestSiteRoom._Ready to handle >4 players at the campfire
 			var restSiteRoomType = typeof(MegaCrit.Sts2.Core.Nodes.Rooms.NRestSiteRoom);
 			var restSiteReadyMethod = restSiteRoomType.GetMethod(
@@ -295,6 +348,18 @@ public static class Sts2Unlimited
 		Log.LogMessage(LogLevel.Info, LogType.Generic,
 			$"[HostPatch] StartENetHost called with port={port} maxClients={maxClients}, overriding to {MaxPlayersOverride}");
 		maxClients = MaxPlayersOverride;
+		return true;
+	}
+
+	// Shared by NCharacterSelectScreen and NCustomRunScreen's InitializeMultiplayerAsHost — both
+	// have the same (INetGameService gameService, int maxPlayers) signature, matched by parameter
+	// name regardless of declaring type (see DifficultyPatch's Prefix_ScaleHpForMultiplayer for the
+	// same pattern).
+	private static bool Patch_LobbyInitMaxPlayers(ref int maxPlayers)
+	{
+		Log.LogMessage(LogLevel.Info, LogType.Generic,
+			$"[HostPatch] InitializeMultiplayerAsHost called with maxPlayers={maxPlayers}, overriding to {MaxPlayersOverride}");
+		maxPlayers = MaxPlayersOverride;
 		return true;
 	}
 


### PR DESCRIPTION
## Root cause

The Workshop bug reports (\"doesn't allow more than 4 players\") trace back to `b215ae7`, six weeks before v0.6.0 — unrelated to the recent difficulty-scaling release. That commit removed the Harmony patches on `NCharacterSelectScreen`/`NCustomRunScreen`'s `InitializeMultiplayerAsHost`, leaving its `maxPlayers` parameter hardcoded at vanilla's `4`.

That value becomes `StartRunLobby.MaxPlayers`, which is what actually gates `TryAddPlayerInFirstAvailableSlot` (confirmed via IL disassembly of the shipped game DLL) — the method that seats a joining player. `StartSteamHost`/`StartENetHost`'s `maxClients` override (still intact this whole time) only controls the transport-level accept limit (Steam lobby member count / ENet socket cap). So a 5th+ player could connect at the network level but still get refused an actual run slot by this unpatched application-level cap.

## Why it was removed, and why restoring it should be safe

`b215ae7`'s message says restoring this override previously caused a partial-lobby black screen (host expecting N ready signals with fewer real players connected). I traced `IsAboutToBeginGame`/`BeginRunForAllPlayersIfAllReady` in the game's IL — both only wait on players actually present in `StartRunLobby.Players`, not on `MaxPlayers` — so that mechanism shouldn't reproduce the stall.

## Verification

- Live 2-of-8 partial lobby locally (host + 1 join via `-fastmp=host`/`-fastmp=join`, `MaxPlayersOverride=8`): run started cleanly, `[StartRunLobby] Received LobbyBeginRunMessage` on the client, no errors/stalls in either instance's log.
- Confirmed via IL that the difficulty-scaling branch (v0.6.0) itself never touched this code path — this bug predates it.